### PR TITLE
Improved python absolute script path determination, compatibility of Qt project and deploy.sh under Linux

### DIFF
--- a/data/FMI_template/projects/Qt/FMI_template.pro
+++ b/data/FMI_template/projects/Qt/FMI_template.pro
@@ -44,6 +44,10 @@ unix|mac {
 	VERSION = $${VER_MAJ}.$${VER_MIN}.$${VER_PAT}
 }
 
+unix {
+        QMAKE_POST_LINK += $$quote(mv $${DESTDIR}/lib$${TARGET}.so $${DESTDIR}/$${TARGET}.so)
+}
+
 INCLUDEPATH = ../../src
 
 SOURCES += \

--- a/scripts/FMIGenerator.py
+++ b/scripts/FMIGenerator.py
@@ -161,7 +161,7 @@ class FMIGenerator:
 		# this python script: ../data/FMIProject
 
 		# get the path of the current python script
-		scriptpath = os.path.abspath(os.path.dirname(sys.argv[0]))
+		scriptpath = os.path.dirname(os.path.abspath(__file__))
 		self.printMsg("Script path        : {}".format(scriptpath))
 
 		# relative path (from script file) to resource/template directory


### PR DESCRIPTION
See commit comments on issues observed and fixed. Tried out scripts/main.py and validated output by repeating steps to create the P_Control example. FMU successfully build and simulated in OpenModelica 1.13.0 under Ubuntu Linux. 
Also made smoke test on building .pro from projects/Qt in Release from QtCreator and executing build/deploy.sh. FMU is built, too. 