### PR TITLE
Add p7zip-full to required software

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,14 +67,14 @@ Simply install the python packages and pyqt5.
 _Ubuntu 16.04 - Python 2.7_
 
 ```bash
-> sudo apt get install cmake built-essential qt5-default qt5-qmake qtcreator python-pyqt5 pyqt5-dev-tools 
+> sudo apt get install cmake built-essential qt5-default qt5-qmake qtcreator python-pyqt5 pyqt5-dev-tools p7zip-full
 ```
 The package `pyqt5-dev-tools` contains the scripts `pyuic5` and `pyrcc5` needed for development of the FMIGenerator itself.
 
 _Ubuntu 16.04 - Python 3_
 
 ```bash
-> sudo apt get install cmake built-essential qt5-default qt5-qmake qtcreator python3 python3-pyqt5 pyqt5-dev-tools 
+> sudo apt get install cmake built-essential qt5-default qt5-qmake qtcreator python3 python3-pyqt5 pyqt5-dev-tools p7zip-full
 ```
 
 #### Mac


### PR DESCRIPTION
`7za` is needed by `deploy.sh` script in stateless P-Controller tutorial. I had to install `p7zip-full` to avoid the following error:

```
$ ~/FMUs/OsziEE/build$ ./deploy.sh 
./deploy.sh: line 27: 7za: command not found
mv: cannot stat 'OsziEE.zip': No such file or directory
```
After installing `p7zip-full` I was able to run `deploy.sh` without problems.